### PR TITLE
Update HMAS-wdl to v1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ WORKDIR /
 
 # Version arguments
 # ARG variables only persist during build time
-# using latest release from 2023/06/20
-ARG HMAS_VERSION="1.0.0"
+ARG HMAS_VERSION="1.2.0"
 ARG HMAS_SRC_URL=https://github.com/ncezid-biome/HMAS-QC-Pipeline2/archive/refs/tags/v${HMAS_VERSION}.zip
 
 # metadata labels
@@ -53,6 +52,8 @@ RUN mamba create -y --name hmas -c conda-forge -c bioconda -c defaults \
     cutadapt=3.5 \
     pear \
     vsearch=2.22.1 \
+    multiqc=1.21 \
+    fastqc=0.12.1 \
     nextflow=22.10.6 && \
     mamba clean -a -y
 

--- a/tasks/task_hmas.wdl
+++ b/tasks/task_hmas.wdl
@@ -5,10 +5,10 @@ task hmas {
     Array[File] read1
     Array[File] read2
     File primers
-    String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.0.0"
-    Int memory = 32
-    Int cpu = 12
-    Int disk_size = 500
+    String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.2.0"
+    Int memory = 16
+    Int cpu = 8
+    Int disk_size = 100
   }
   command <<<
     date | tee DATE
@@ -30,16 +30,16 @@ task hmas {
     cp -r /HMAS-QC-Pipeline2/* ./
 
     # Run nextflow
-    nextflow run hmas2.nf --outdir OUT --reads reads --primer ~{primers}
+    nextflow run hmas2.nf --outdir OUT --reads reads --primer ~{primers} 
 
   >>>
   output {
     String hmas_docker = docker
     String analysis_date = read_string("DATE")
     File hmas_report = "OUT/report.csv"
-    Array[File] hmas_clean_read1 = glob("OUT/*/temp/*.1.fastq")
-    Array[File] hmas_clean_read2 = glob("OUT/*/temp/*.2.fastq")
-    Array[File] hmas_consensus_fasta = glob("OUT/*/*final.unique.fasta")
+    File hmas_multiqc_html = "OUT/multiqc_report.html"
+    File hmas_mqc_yaml = "OUT/report_mqc.yaml"
+    Array[File] hmas_final_fasta = glob("OUT/*/*final.unique.fasta")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/task_hmas.wdl
+++ b/tasks/task_hmas.wdl
@@ -6,7 +6,7 @@ task hmas {
     Array[File] read2
     File primers
     String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.2.0"
-    Int memory = 18
+    Int memory = 24
     Int cpu = 8
     Int disk_size = 100
   }

--- a/tasks/task_hmas.wdl
+++ b/tasks/task_hmas.wdl
@@ -6,7 +6,7 @@ task hmas {
     Array[File] read2
     File primers
     String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.2.0"
-    Int memory = 16
+    Int memory = 18
     Int cpu = 8
     Int disk_size = 100
   }

--- a/workflows/hmas.wdl
+++ b/workflows/hmas.wdl
@@ -19,9 +19,9 @@ workflow hmas_wf {
   }
   output {
     File hmas_report = hmas.hmas_report
-    Array[File] hmas_clean_read1 = hmas.hmas_clean_read1
-    Array[File] hmas_clean_read2 = hmas.hmas_clean_read2
-    Array[File] hmas_consensus_fasta = hmas.hmas_consensus_fasta
+    File hmas_multiqc_html = hmas.hmas_multiqc_html
+    File hmas_mqc_yaml = hmas.hmas_mqc_yaml
+    Array[File] hmas_final_fasta = hmas.hmas_final_fasta
     String hmas_docker = hmas.hmas_docker
     String analysis_date = hmas.analysis_date
   }


### PR DESCRIPTION
Changes implemented in this PR:
- [HMAS-QC-Pipeline2](https://github.com/ncezid-biome/HMAS-QC-Pipeline2/tree/v1.2.0) has been updated to `v1.2.0`
  - Dockerfile has been updated
  - New docker container has been pushed to the GAR
  - hmas task docker has been updated
- hmas task resources has been reduced to make computation cheaper
-  the `hmas_clean_read1` and `hmas_clean_read2` outputs have been removed as they were infact not the clean reads out of the output, just the intermediary output from cutadapt
- New outputs added
  - `hmas_multiqc_html` with the multiQC report
  - `hmas_mqc_yaml` not sure what this one contains, but could be machine-parsable in the future
- `hmas_consensus_fasta` has been renamed to `hmas_final_fasta` as it was in fact NOT a consensus sequence 

Test on Terra.bio: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Ines_Sandbox/job_history/935a9b26-1719-4288-934b-f53cdd9b2311