### PR TITLE
[HMAS] update version to 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,19 @@ RUN mamba create -y --name hmas -c conda-forge -c bioconda -c defaults \
     biopython=1.84 && \
     mamba clean -a -y
 
-# set locale settings to UTF-8
-# set the environment, put new hmas conda env in PATH by default
-ENV PATH /opt/conda/envs/hmas/bin:$PATH \
-    LC_ALL=C.UTF-8
+# activate the conda environment
+RUN conda init bash
+
+RUN echo "conda activate hmas" >> ~/.bashrc
+
+# Set up conda environment
+ENV CONDA_PREFIX=/opt/conda/envs/hmas
+ENV PATH=$CONDA_PREFIX/bin:$PATH
+
+# Set utf-8 encoding
+ENV LC_ALL=C.UTF-8
 
 # set final working directory to /data
 WORKDIR /data
+
+SHELL ["/bin/bash", "-c"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /
 
 # Version arguments
 # ARG variables only persist during build time
-ARG HMAS_VERSION="1.2.0"
+ARG HMAS_VERSION="1.2.1"
 ARG HMAS_SRC_URL=https://github.com/ncezid-biome/HMAS-QC-Pipeline2/archive/refs/tags/v${HMAS_VERSION}.zip
 
 # metadata labels
@@ -21,7 +21,9 @@ LABEL description="A WDL wrapper around ncezid-biome/HMAS-QC-Pipeline2 for Terra
 LABEL website="https://github.com/ncezid-biome/HMAS-QC-Pipeline2"
 LABEL license="https://github.com/ncezid-biome/HMAS-QC-Pipeline2/blob/sample_base/LICENSE"
 LABEL maintainer1="Inês Mendes"
+LABEL maintainer2="Michal Babinski"
 LABEL maintainer.email1="ines.mendes@theiagen.com"
+LABEL maintainer.email2="michal.babinski@theiagen.com"
 
 # install base dependencies; cleanup apt garbage
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -49,12 +51,13 @@ RUN ls /HMAS-QC-Pipeline2/bin/
 RUN mamba create -y --name hmas -c conda-forge -c bioconda -c defaults \
     python=3.9 \
     pandas=1.5.3 \
-    cutadapt=3.5 \
+    cutadapt=4.8 \
     pear \
     vsearch=2.22.1 \
     multiqc=1.21 \
     fastqc=0.12.1 \
-    nextflow=22.10.6 && \
+    nextflow=22.10.6 \
+    biopython=1.84 && \
     mamba clean -a -y
 
 # set locale settings to UTF-8
@@ -64,7 +67,3 @@ ENV PATH /opt/conda/envs/hmas/bin:$PATH \
 
 # set final working directory to /data
 WORKDIR /data
-
-# run test profile
-# RUN cd /HMAS-QC-Pipeline2/ && \
-#     nextflow run /HMAS-QC-Pipeline2/hmas2.nf -profile test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # HMAS-wdl
-A WDL wrapper around HMAS-QC-Pipeline2 for Terra.bio
+A WDL wrapper around HMAS-QC-Pipeline2 nextflow for Terra.bio

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # HMAS-wdl
-A WDL wrapper around HMAS-QC-Pipeline2 nextflow for Terra.bio
+A WDL wrapper around HMAS-QC-Pipeline2 for Terra.bio

--- a/tasks/task_hmas.wdl
+++ b/tasks/task_hmas.wdl
@@ -5,7 +5,7 @@ task hmas {
     Array[File] read1
     Array[File] read2
     File primers
-    String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.2.0"
+    String docker="us-docker.pkg.dev/general-theiagen/internal/hmas:1.2.1"
     Int memory = 24
     Int cpu = 8
     Int disk_size = 100


### PR DESCRIPTION
This PR updates the following for HMAS and closes issue #2:

- Updates HMAS version to 1.2.1
- Updates cutadapt version to 4.8
- Add biopython specification of 1.84
These are consistent with HMAS versions found here:
https://github.com/ncezid-biome/HMAS-QC-Pipeline2/blob/main/bin/hmas.yaml

The following outputs are changed as well, this is due to how version 1.2.1 fuses the --outdir prefix with the version and timestamp, so outputs are now collected as the following:

```
File hmas_report = glob("OUT_v*/*report*.csv")[0]
File hmas_multiqc_html = glob("OUT_v*/multiqc_report*.html")[0]
File hmas_mqc_yaml = glob("OUT_v*/report_mqc.yaml")[0]
Array[File] hmas_final_fasta = glob("OUT_v*/*/*.final.unique.fasta")
```

The changes were tested against HMAS_sample datatable and the run can be found [here on terra](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/CDPH_Bioinformatics_Development/job_history/d2c3116b-0632-43f2-a89b-648e3a0eb017)

The version change will also have the report in a pattern as such: `report_v1.2.1_$(date '+%Y%m%d_%H%M%S').csv` 
Example: `report_v1.2.1_20241220_182041.csv`

Before in v1.2.0 the report was simply  `report.csv`,

### Testing
User can repeat the test above and test with other data. I tested with the only HMAS test data I could find. 

